### PR TITLE
Fix: updating the position of a marker leads to a crash in leaflet

### DIFF
--- a/leaflet-marker.html
+++ b/leaflet-marker.html
@@ -621,7 +621,7 @@ Element which defines a maker  (<a href="http://leafletjs.com/reference.html#mar
 
 		positionChanged: function() {
 			if (this.feature) {
-				this.feature.setLatLng(L.LatLng(this.latitude, this.longitude));
+				this.feature.setLatLng(L.latLng(this.latitude, this.longitude));
 			}
 		},
 


### PR DESCRIPTION
Hello,

While using markers with data binding I found that changing the position leaded to an exception in leaflet: "cannot read property lat from undefined".
The issue was that the proper object to pass latitude/longitude is created using L.latLng instead of L.LatLng.

Thanks!
Benjamin